### PR TITLE
Fix problems

### DIFF
--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -63,11 +63,10 @@ impl<H: Hash + Clone> MerkleTree<H> {
         }
 
         let transactions_hash = Self::get_hashes_of_transactions(&transactions);
-
-        let mut nodes = Vec::new();
-        for hash in transactions_hash {
-            nodes.push(Box::new(MerkleNode::new(hash, None, None)));
-        }
+        let mut nodes: Vec<Box<MerkleNode>> = transactions_hash
+            .into_iter()
+            .map(|hash| Box::new(MerkleNode::new(hash, None, None)))
+            .collect();
 
         while nodes.len() > 1 {
             let mut parents = Vec::new();

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -83,14 +83,14 @@ impl<H: Hash + Clone> MerkleTree<H> {
     }
 
     fn get_hashes_of_transactions(transactions: &Vec<H>) -> Vec<u64> {
-        let mut transactions_hash = Vec::new();
-        for transaction in transactions {
-            let mut hasher = DefaultHasher::new();
-            transaction.hash(&mut hasher);
-            let transaction_hash = hasher.finish();
-            transactions_hash.push(transaction_hash);
-        }
-        transactions_hash
+        transactions
+            .iter()
+            .map(|transaction| {
+                let mut hasher = DefaultHasher::new();
+                transaction.hash(&mut hasher);
+                hasher.finish()
+            })
+            .collect()
     }
 
     pub fn verify(&mut self, transaction: H, proof: Vec<SiblingHash>) -> bool {

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -86,7 +86,7 @@ impl<H: Hash + Clone> MerkleTree<H> {
         })
     }
 
-    fn get_hashes_of_transactions(transactions: &Vec<H>) -> Vec<u64> {
+    fn get_hashes_of_transactions(transactions: &[H]) -> Vec<u64> {
         transactions
             .iter()
             .map(|transaction| {
@@ -132,14 +132,12 @@ impl<H: Hash + Clone> MerkleTree<H> {
                     proof.push(SiblingHash::Right(right_sibling.hash_value))
                 });
                 added_proof = true;
-                return;
             }
             if Self::recursive_get_proof(left, proof, transaction_hash) {
                 current_node.right_son.as_ref().inspect(|right_sibling| {
                     proof.push(SiblingHash::Right(right_sibling.hash_value))
                 });
                 added_proof = true;
-                return;
             }
         });
 
@@ -150,7 +148,6 @@ impl<H: Hash + Clone> MerkleTree<H> {
                     .as_ref()
                     .inspect(|left_sibling| proof.push(SiblingHash::Left(left_sibling.hash_value)));
                 added_proof = true;
-                return;
             }
             if Self::recursive_get_proof(right, proof, transaction_hash) {
                 current_node
@@ -158,7 +155,6 @@ impl<H: Hash + Clone> MerkleTree<H> {
                     .as_ref()
                     .inspect(|left_sibling| proof.push(SiblingHash::Left(left_sibling.hash_value)));
                 added_proof = true;
-                return;
             }
         });
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -72,8 +72,10 @@ impl<H: Hash + Clone> MerkleTree<H> {
         while nodes.len() > 1 {
             let mut parents = Vec::new();
 
-            for _ in (0..nodes.len()).step_by(2) {
-                let parent = Self::create_parent_from_siblings(nodes.pop(), nodes.pop());
+            let mut iter = nodes.into_iter();
+
+            while let (Some(left_son), right_son) = (iter.next(), iter.next()) {
+                let parent = Self::create_parent_from_siblings(Some(left_son), right_son);
                 parents.push(Box::new(parent));
             }
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -41,15 +41,19 @@ impl<H: Hash + Clone> MerkleTree<H> {
     ) -> MerkleNode {
         let mut hasher = DefaultHasher::new();
 
-        if let Some(left_sibling) = &left_son {
+        left_son.as_ref().map(|left_sibling| {
             left_sibling.hash_value.hash(&mut hasher);
-            if let Some(right_sibling) = &right_son {
-                right_sibling.hash_value.hash(&mut hasher);
-            } else {
-                right_son = left_son.clone();
-                left_sibling.hash_value.hash(&mut hasher);
+            match &right_son {
+                Some(right_sibling) => {
+                    right_sibling.hash_value.hash(&mut hasher);
+                }
+                None => {
+                    right_son = left_son.clone();
+                    left_sibling.hash_value.hash(&mut hasher);
+                }
             }
-        }
+        });
+
         MerkleNode::new(hasher.finish(), left_son, right_son)
     }
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -269,4 +269,26 @@ pub mod test {
 
         assert!(!merkle_tree.verify(transaction, proof));
     }
+
+    #[test]
+    fn a_merkle_tree_can_have_generic_transactions() {
+        let transactions = vec![1000, 1500, 2000, 3000, 4000, 5500, 7000, 8700];
+        let mut merkle_tree = MerkleTree::new(transactions.clone()).unwrap();
+        let transaction = transactions[0].clone();
+        let proof = merkle_tree.get_proof(transaction.clone());
+
+        assert!(merkle_tree.verify(transaction, proof));
+
+        let transactions = vec![
+            "De aquel amor",
+            "De musica ligera",
+            "Nada nos libra,",
+            "Nada mas queda",
+        ];
+        let mut merkle_tree = MerkleTree::new(transactions.clone()).unwrap();
+        let transaction = transactions[0];
+        let proof = merkle_tree.get_proof(transaction);
+
+        assert!(merkle_tree.verify(transaction, proof));
+    }
 }


### PR DESCRIPTION
## Summary
This PR fix some problems related to the complexity of reading the implementation of the Merkle tree

### Changes
- Fixed an issue where you can wrongly create a Merkle tree with no elements, now returns an `Err`
- Changed Most `if let` with `match` and `map` functions
- Added one test for other data types that implements `Hash` and longer `String`s