### PR TITLE
Code refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+sha3 = "0.10.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+digest = "0.10.7"
 sha3 = "0.10.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,6 @@ edition = "2021"
 
 [dependencies]
 digest = "0.10.7"
+
+[dev-dependencies]
 sha3 = "0.10.8"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 Implementation of a Merkle Tree data structure in Rust
 
 ## Primitives
-- Can be built from a list of elements that implements `AsRef<[u8]>` and `Clone`
+- Can be built from a list of elements that implement `AsRef<[u8]>` and `Clone`
 - Can generate a proof and validate that an element is in the tree with that proof
-- Can add new elementss to the tree
+- Can add new elements to the tree
 
 ## TODO
 - Add documentation

--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Implementation of a Merkle Tree data structure in Rust
 - Can be built from a list of elements that implements `AsRef<[u8]>` and `Clone`
 - Can generate a proof and validate that an element is in the tree with that proof
 - Can add new elementss to the tree
+
+## TODO
+- Add documentation

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # merkle-tree
 Implementation of a Merkle Tree data structure in Rust
+
+## Primitives
+- Can be built from a list of elements that implements `AsRef<[u8]>` and `Clone`
+- Can generate a proof and validate that an element is in the tree with that proof
+- Can add new elementss to the tree

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -157,11 +157,9 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
                     return true;
                 }
 
-                return false;
+                false
             }
-            MerkleNode::Leaf(_) => {
-                return false;
-            }
+            MerkleNode::Leaf(_) => false,
         }
     }
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -81,8 +81,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
         }
 
         let mut nodes: Vec<MerkleNode> = transactions
-            .clone()
-            .into_iter()
+            .iter()
             .map(|transaction| {
                 let mut hasher = Sha3_256::new();
                 hasher.update(transaction);

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -103,7 +103,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
         }
 
         Ok(Self {
-            merkle_root: nodes[0].clone(),
+            merkle_root: nodes.pop().unwrap(), // never panics!
             leaves: transactions,
         })
     }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -25,7 +25,7 @@ enum MerkleNode {
 }
 pub struct MerkleTree<H: AsRef<[u8]> + Clone> {
     merkle_root: MerkleNode,
-    leafs: Vec<H>,
+    leaves: Vec<H>,
 }
 
 impl MerkleNode {
@@ -105,7 +105,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
 
         Ok(Self {
             merkle_root: nodes[0].clone(),
-            leafs: transactions,
+            leaves: transactions,
         })
     }
 
@@ -176,8 +176,8 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
     }
 
     pub fn add(&mut self, transaction: H) -> Result<(), &'static str> {
-        self.leafs.push(transaction);
-        self.merkle_root = Self::create_tree(self.leafs.clone())?.merkle_root;
+        self.leaves.push(transaction);
+        self.merkle_root = Self::create_tree(self.leaves.clone())?.merkle_root;
         Ok(())
     }
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -92,16 +92,16 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
             .collect();
 
         // We loop all the elements and construct the next level of the tree, we stop once there is only one element (the root)
+        let mut parents: Vec<MerkleNode> = Vec::with_capacity(nodes.len());
         while nodes.len() > 1 {
-            let mut parents = Vec::new();
             let mut iter = nodes.into_iter();
 
             while let (Some(left_son), right_son) = (iter.next(), iter.next()) {
                 let parent = Self::create_parent_from_siblings(left_son, right_son);
                 parents.push(parent);
             }
-
-            nodes = parents;
+            nodes = parents[0..parents.len()].to_vec();
+            parents.clear();
         }
 
         Ok(Self {

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -103,7 +103,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
         }
 
         Ok(Self {
-            merkle_root: nodes.pop().unwrap(), // never panics!
+            merkle_root: nodes.pop().unwrap(), // never panics, as 'nodes' have exactly one element at this point!
             leaves: transactions,
         })
     }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -71,7 +71,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
         hasher.update(right_son.get_hash_value());
 
         Rc::new(MerkleNode::Inner(InnerNode::new(
-            hasher.finalize().to_ascii_lowercase(),
+            hasher.finalize().to_vec(),
             left_son,
             right_son,
         )))
@@ -88,7 +88,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
                 let mut hasher = D::new();
                 hasher.update(transaction);
                 Rc::new(MerkleNode::Leaf(LeafNode::new(
-                    hasher.finalize().to_ascii_lowercase(),
+                    hasher.finalize().to_vec(),
                     transaction.clone(),
                 )))
             })
@@ -115,7 +115,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
     pub fn verify<D: digest::Digest>(&self, transaction: H, proof: Vec<SiblingHash>) -> bool {
         let mut hasher = D::new();
         hasher.update(transaction);
-        let mut transaction = hasher.finalize().to_ascii_lowercase();
+        let mut transaction = hasher.finalize().to_vec();
         for sibling_hash in proof {
             let mut hasher = D::new();
             match sibling_hash {
@@ -129,7 +129,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
                 }
             }
 
-            transaction = hasher.finalize().to_ascii_lowercase();
+            transaction = hasher.finalize().to_vec();
         }
 
         transaction == self.merkle_root.get_hash_value()
@@ -171,11 +171,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
         let mut hasher = D::new();
         hasher.update(transaction);
 
-        Self::recursive_get_proof(
-            &self.merkle_root,
-            &mut proof,
-            hasher.finalize().to_ascii_lowercase(),
-        );
+        Self::recursive_get_proof(&self.merkle_root, &mut proof, hasher.finalize().to_vec());
         proof
     }
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -65,7 +65,6 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
     ) -> MerkleNode {
         let mut hasher = Sha3_256::new();
         hasher.update(left_son.get_hash_value());
-
         let right_son = right_son.unwrap_or_else(|| left_son.clone());
         hasher.update(right_son.get_hash_value());
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -14,6 +14,7 @@ struct InnerNode {
 #[derive(Clone)]
 struct LeafNode {
     hash_value: Vec<u8>,
+    data: Vec<u8>,
 }
 
 #[derive(Clone)]
@@ -46,8 +47,8 @@ impl InnerNode {
 }
 
 impl LeafNode {
-    pub fn new(hash_value: Vec<u8>) -> Self {
-        Self { hash_value }
+    pub fn new(hash_value: Vec<u8>, data: Vec<u8>) -> Self {
+        Self { hash_value, data }
     }
 }
 
@@ -85,6 +86,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
                 hasher.update(transaction);
                 Rc::new(MerkleNode::Leaf(LeafNode::new(
                     hasher.finalize().to_ascii_lowercase(),
+                    transaction.as_ref().to_vec(),
                 )))
             })
             .collect();

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -177,7 +177,8 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
 
     pub fn add<D: Digest>(&mut self, transaction: H) -> Result<(), &'static str> {
         self.leaves.push(transaction);
-        self.merkle_root = Self::create_tree::<D>(self.leaves.clone())?.merkle_root;
+        let leaves = std::mem::take(&mut self.leaves);
+        *self = Self::create_tree::<D>(leaves)?;
         Ok(())
     }
 }

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -62,26 +62,19 @@ impl<H: Hash + Clone> MerkleTree<H> {
     // Fathers must have at least one son, if it does not have one, we clone the left one
     fn create_parent_from_siblings(
         left_son: MerkleNode,
-        mut right_son: Option<MerkleNode>,
+        right_son: Option<MerkleNode>,
     ) -> MerkleNode {
         let mut hasher = DefaultHasher::new();
 
         left_son.get_hash_value().hash(&mut hasher);
 
-        match &right_son {
-            Some(right_sibling) => {
-                right_sibling.get_hash_value().hash(&mut hasher);
-            }
-            None => {
-                right_son = Some(left_son.clone());
-                left_son.get_hash_value().hash(&mut hasher);
-            }
-        }
+        let right_son = right_son.unwrap_or_else(|| left_son.clone());
+        right_son.get_hash_value().hash(&mut hasher);
 
         MerkleNode::Inner(InnerNode::new(
             hasher.finish(),
             Rc::new(left_son),
-            Rc::new(right_son.unwrap()),
+            Rc::new(right_son),
         ))
     }
 

--- a/src/merkle_tree.rs
+++ b/src/merkle_tree.rs
@@ -1,7 +1,5 @@
 use std::rc::Rc;
 
-use sha3::Digest;
-
 pub enum SiblingHash<'a> {
     Left(&'a [u8]),
     Right(&'a [u8]),
@@ -54,12 +52,12 @@ impl LeafNode {
 }
 
 impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
-    pub fn new<D: Digest>(transactions: Vec<H>) -> Result<Self, &'static str> {
+    pub fn new<D: digest::Digest>(transactions: Vec<H>) -> Result<Self, &'static str> {
         Self::create_tree::<D>(transactions)
     }
 
     // Fathers must have at least one son, if it does not have one, we clone the left one
-    fn create_parent_from_siblings<D: Digest>(
+    fn create_parent_from_siblings<D: digest::Digest>(
         left_son: MerkleNode,
         right_son: Option<MerkleNode>,
     ) -> MerkleNode {
@@ -75,7 +73,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
         ))
     }
 
-    fn create_tree<D: Digest>(transactions: Vec<H>) -> Result<MerkleTree<H>, &'static str> {
+    fn create_tree<D: digest::Digest>(transactions: Vec<H>) -> Result<MerkleTree<H>, &'static str> {
         if transactions.is_empty() {
             return Err("Can't create a tree without elements");
         }
@@ -108,7 +106,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
         })
     }
 
-    pub fn verify<D: Digest>(&self, transaction: H, proof: Vec<SiblingHash>) -> bool {
+    pub fn verify<D: digest::Digest>(&self, transaction: H, proof: Vec<SiblingHash>) -> bool {
         let mut hasher = D::new();
         hasher.update(transaction);
         let mut transaction = hasher.finalize().to_ascii_lowercase();
@@ -162,7 +160,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
         }
     }
 
-    pub fn get_proof<D: Digest>(&self, transaction: H) -> Vec<SiblingHash> {
+    pub fn get_proof<D: digest::Digest>(&self, transaction: H) -> Vec<SiblingHash> {
         let mut proof = Vec::new();
         let mut hasher = D::new();
         hasher.update(transaction);
@@ -175,7 +173,7 @@ impl<H: AsRef<[u8]> + Clone> MerkleTree<H> {
         proof
     }
 
-    pub fn add<D: Digest>(&mut self, transaction: H) -> Result<(), &'static str> {
+    pub fn add<D: digest::Digest>(&mut self, transaction: H) -> Result<(), &'static str> {
         self.leaves.push(transaction);
         let leaves = std::mem::take(&mut self.leaves);
         *self = Self::create_tree::<D>(leaves)?;


### PR DESCRIPTION
# Summary
This PR make some changes in the structure of the `Merkle Tree`, making it easier to read and more performant

## Changes
- Added new structs and enums to better represent the tree structure
- Increased performance by not allocating new memory when creating the tree
- Use of the `sha3` crate instead of the `DefaultHasher`
- Updated the `README` with the primitives of the structure